### PR TITLE
feat: Add expenses by payment type graph to dashboard

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -61,6 +61,12 @@
         <canvas id="categoryExpensesChart"></canvas>
     </div>
 </div>
+<div class="row">
+    <div class="col-md-6 mb-4">
+        <h5>Expenses by Payment Type</h5>
+        <canvas id="paymentTypeExpensesChart"></canvas>
+    </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -123,6 +129,36 @@
     new Chart(
         document.getElementById('categoryExpensesChart'),
         categoryConfig
+    );
+
+    // Payment Type Expenses Chart
+    const paymentTypeData = {
+        labels: {{ payment_type_expenses.keys()|list|tojson }},
+        datasets: [{
+            label: 'Expenses by Payment Type',
+            data: {{ payment_type_expenses.values()|list|tojson }},
+            backgroundColor: [
+                '#4e73df', '#1cc88a', '#36b9cc', '#f6c23e', '#e74a3b',
+                '#858796', '#5a5c69', '#fd7e14', '#20c997', '#6f42c1'
+            ],
+            hoverOffset: 4
+        }]
+    };
+
+    const paymentTypeConfig = {
+        type: 'pie',
+        data: paymentTypeData,
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { position: 'bottom' }
+            }
+        }
+    };
+
+    new Chart(
+        document.getElementById('paymentTypeExpensesChart'),
+        paymentTypeConfig
     );
 </script>
 {% endblock %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+import os
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
This commit introduces a new pie chart to the dashboard that displays the breakdown of expenses by payment type for the selected month and year.

- Modified `app/routes/main.py` to query and aggregate expenses by payment type.
- Updated `app/templates/dashboard.html` to include a new canvas and the necessary Chart.js configuration to render the pie chart.
- Added `tests/conftest.py` to fix the test environment by ensuring the app module is in the Python path, allowing tests to run correctly.